### PR TITLE
Fix pagination

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,26 @@ last_fetch_was_at = datetime.datetime.now() - datetime.timedelta(days=1)  # use 
 new_data = client.export_highlights(last_fetch_was_at.isoformat())
 ```
 
+#### Daily Review Highlights
+
+Get the daily review details and highlights
+
+```python
+daily_review = client.get_daily_review()
+
+completed = daily_review.review_completed # True or False
+print(completed) # True or False
+
+highlights = daily_review.highlights
+```
+
+or a generator of only the highlights.
+
+```python
+for highlight in client.get_daily_review_highlights():
+	print(highlight.text)
+```
+
 ### Readwise Readwise API
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,21 @@ for book in books:
 			print(highlight.text)
 ```
 
+#### Export All Highlights
+
+```python
+from readwise import Readwise
+
+client = Readwise(token='<your_api_token>')
+
+# Get all of a user's books/highlights from all time
+all_data = client.export_highlights()
+
+# Later, if you want to get new highlights updated since your last fetch of allData, do this.
+last_fetch_was_at = datetime.datetime.now() - datetime.timedelta(days=1)  # use your own stored date
+new_data = client.export_highlights(last_fetch_was_at.isoformat())
+```
+
 ### Readwise Readwise API
 
 ```python

--- a/readwise/api.py
+++ b/readwise/api.py
@@ -7,7 +7,9 @@ import requests
 from requests.models import ChunkedEncodingError
 
 from readwise.models import (
+    DailyReviewHighlight,
     ReadwiseBook,
+    ReadwiseDailyReview,
     ReadwiseExportHighlight,
     ReadwiseExportResults,
     ReadwiseHighlight,
@@ -238,9 +240,38 @@ class Readwise:
                     break
                 page += 1
 
+    def get_daily_review(self) -> ReadwiseDailyReview:
+        """Get Readwise Daily Review.
+
+        Returns:
+            A ReadwiseDailyReview object
+        """
+        return ReadwiseDailyReview(**self.get("/review/").json())
+
+    def get_daily_review_highlights(
+        self,
+    ) -> Generator[DailyReviewHighlight, None, None]:
+        """Get Readwise Daily Review.
+
+        Returns:
+            A ReadwiseDailyReview object
+        """
+        daily_review = self.get_daily_review()
+        for highlight in daily_review.highlights:
+            yield DailyReviewHighlight(**highlight)
+
     def export_highlights(
         self, updated_after: str = None, ids: list[str] = None
-    ) -> Generator[dict, None, None]:
+    ) -> Generator[ReadwiseExportResults, None, None]:
+        """
+        Export all highlights from Readwise.
+
+        Args:
+            updated_after: date highlight was last updated
+            ids: A list of book ids
+        Yields:
+            A generator of ReadwiseExportResults objects
+        """
         params = {}
         if updated_after:
             params["updatedAfter"] = updated_after

--- a/readwise/api.py
+++ b/readwise/api.py
@@ -344,6 +344,9 @@ class Readwise:
                     note=highlight["note"],
                     location=highlight["location"],
                     location_type=highlight["location_type"],
+                    highlighted_at=datetime.fromisoformat(highlight["highlighted_at"])
+                    if highlight["highlighted_at"]
+                    else None,
                     url=highlight["url"],
                     color=highlight["color"],
                     updated=datetime.fromisoformat(highlight["updated"])

--- a/readwise/api.py
+++ b/readwise/api.py
@@ -627,7 +627,7 @@ class ReadwiseReader:
             data = response.json()
             yield data
             if (
-                type(data) == list
+                isinstance(data, list)
                 or not data.get("nextPageCursor")
                 or data.get("nextPageCursor") == pageCursor
             ):

--- a/readwise/models.py
+++ b/readwise/models.py
@@ -42,6 +42,7 @@ class ReadwiseHighlight:
     note: str
     location: int
     location_type: str
+    highlighted_at: datetime | None
     url: str | None
     color: str
     updated: datetime | None

--- a/readwise/models.py
+++ b/readwise/models.py
@@ -31,9 +31,7 @@ class ReadwiseBook:
 
 @dataclass
 class ReadwiseHighlight:
-    """
-    Represents a Readwise highlight.
-    """
+    """Represents a Readwise highlight."""
 
     id: str
     text: str
@@ -49,9 +47,7 @@ class ReadwiseHighlight:
 
 @dataclass
 class ReadwiseExportHighlight:
-    """
-    Represents a Readwise highlight.
-    """
+    """Represents a Readwise highlight export."""
 
     id: int
     text: str
@@ -74,6 +70,8 @@ class ReadwiseExportHighlight:
 
 @dataclass
 class ReadwiseExportResults:
+    """Represents a Readwise export result."""
+
     user_book_id: str
     title: str
     author: str
@@ -92,7 +90,40 @@ class ReadwiseExportResults:
 
 
 @dataclass
+class DailyReviewHighlight:
+    """Represents a Readwise Daily Review highlight."""
+
+    text: str
+    title: str
+    author: str
+    url: str
+    source_url: str
+    source_type: str
+    category: str
+    location_type: str
+    location: int
+    note: str
+    highlighted_at: datetime | None
+    highlight_url: str
+    image_url: str
+    id: int
+    api_source: str
+
+
+@dataclass
+class ReadwiseDailyReview:
+    """Represents a Readwise Daily Review."""
+
+    review_id: int
+    review_url: str
+    review_completed: bool
+    highlights: List[dict]
+
+
+@dataclass
 class ReadwiseReaderDocument:
+    """Represents a Readwise Reader Document."""
+
     id: str
     url: str
     source_url: str

--- a/readwise/models.py
+++ b/readwise/models.py
@@ -23,9 +23,13 @@ class ReadwiseBook:
     category: str
     source: str
     num_highlights: int
+    last_highlight_at: datetime
+    updated: datetime
     cover_image_url: str
     highlights_url: str
     source_url: str
+    asin: str
+    tags: List[ReadwiseTag]
     document_note: str
 
 
@@ -85,7 +89,7 @@ class ReadwiseExportResults:
     readwise_url: str
     source_url: str
     book_tags: List[ReadwiseTag] = field(default_factory=list)
-    highlights: List[ReadwiseExportHighlight] = field(default_factory=list)
+    highlights: List[dict] = field(default_factory=list)
     asin: Optional[str] = None
 
 

--- a/readwise/models.py
+++ b/readwise/models.py
@@ -1,16 +1,11 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 
 @dataclass
 class ReadwiseTag:
-    """Represents a Readwise tag.
-
-    Attributes:
-        id: The tag's ID.
-        name: The tag's name.
-    """
+    """Represents a Readwise tag."""
 
     id: str
     name: str
@@ -20,22 +15,6 @@ class ReadwiseTag:
 class ReadwiseBook:
     """
     Represents a Readwise book.
-
-    Attributes:
-        id: The book's ID.
-        title: The book's title.
-        author: The book's author.
-        category: The book's category.
-        source: The book's source.
-        num_highlights: The number of highlights for the book.
-        last_highlight_at: The date and time of the last highlight for the book.
-        updated: The date and time the book was last updated.
-        cover_image_url: The URL of the book's cover image.
-        highlights_url: The URL of the book's highlights.
-        source_url: The URL of the book's source.
-        asin: The book's ASIN.
-        tags: The book's tags.
-        document_note: The book's document note.
     """
 
     id: str
@@ -44,13 +23,9 @@ class ReadwiseBook:
     category: str
     source: str
     num_highlights: int
-    last_highlight_at: datetime | None
-    updated: datetime | None
     cover_image_url: str
     highlights_url: str
     source_url: str
-    asin: str
-    tags: list[ReadwiseTag]
     document_note: str
 
 
@@ -58,18 +33,6 @@ class ReadwiseBook:
 class ReadwiseHighlight:
     """
     Represents a Readwise highlight.
-
-    Attributes:
-        id: The highlight's ID.
-        text: The highlight's text.
-        note: The highlight's note.
-        location: The highlight's location.
-        location_type: The highlight's location type.
-        url: The highlight's URL.
-        color: The highlight's color.
-        updated: The date and time the highlight was last updated.
-        book_id: The ID of the book the highlight is from.
-        tags: The highlight's tags.
     """
 
     id: str
@@ -82,6 +45,50 @@ class ReadwiseHighlight:
     updated: datetime | None
     book_id: str
     tags: list[ReadwiseTag]
+
+
+@dataclass
+class ReadwiseExportHighlight:
+    """
+    Represents a Readwise highlight.
+    """
+
+    id: int
+    text: str
+    location: int
+    location_type: str
+    note: str
+    color: str
+    highlighted_at: str
+    created_at: str
+    updated_at: str
+    external_id: str
+    book_id: int
+    readwise_url: str
+    tags: List[ReadwiseTag] = field(default_factory=list)
+    is_favorite: bool = False
+    is_discard: bool = False
+    url: Optional[str] = None
+    end_location: Optional[int] = None
+
+
+@dataclass
+class ReadwiseExportResults:
+    user_book_id: str
+    title: str
+    author: str
+    readable_title: str
+    source: str
+    cover_image_url: str
+    unique_url: str
+    category: str
+    document_note: str
+    summary: str
+    readwise_url: str
+    source_url: str
+    book_tags: List[ReadwiseTag] = field(default_factory=list)
+    highlights: List[ReadwiseExportHighlight] = field(default_factory=list)
+    asin: Optional[str] = None
 
 
 @dataclass
@@ -103,5 +110,5 @@ class ReadwiseReaderDocument:
     published_date: str
     summary: str
     image_url: str
-    parent_id: Optional[str]
     reading_progress: float
+    parent_id: Optional[str] = None

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -206,7 +206,7 @@ def test_get_export_highlights(mock_get):
             }
         ],
     }
-    export = list(readwise_client.get_export_highlights())
+    export = list(readwise_client.export_highlights())
     assert len(export) == 1
     assert export[0].user_book_id == 1
     assert export[0].title == "Test Book"
@@ -233,15 +233,9 @@ def test_get_export_highlights(mock_get):
     assert export[0].highlights[0].location_type == "page"
     assert export[0].highlights[0].note == "Test Note"
     assert export[0].highlights[0].color == "yellow"
-    assert export[0].highlights[0].highlighted_at == datetime.fromisoformat(
-        "2020-01-01T00:00:00Z"
-    )
-    assert export[0].highlights[0].created_at == datetime.fromisoformat(
-        "2020-01-01T00:00:00Z"
-    )
-    assert export[0].highlights[0].updated_at == datetime.fromisoformat(
-        "2020-01-01T00:00:00Z"
-    )
+    assert export[0].highlights[0].highlighted_at == "2020-01-01T00:00:00Z"
+    assert export[0].highlights[0].created_at == "2020-01-01T00:00:00Z"
+    assert export[0].highlights[0].updated_at == "2020-01-01T00:00:00Z"
     assert export[0].highlights[0].external_id == "test_id"
     assert export[0].highlights[0].end_location is None
     assert export[0].highlights[0].url is None
@@ -254,3 +248,101 @@ def test_get_export_highlights(mock_get):
     assert export[0].highlights[0].is_favorite is False
     assert export[0].highlights[0].is_discard is False
     assert export[0].highlights[0].readwise_url == "https://example.com/readwise"
+
+
+@patch.object(Session, "request")
+def test_get_daily_review(mock_get):
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "review_id": 1,
+        "review_url": "https://example.com/review/1",
+        "review_completed": True,
+        "highlights": [
+            {
+                "text": "Test Highlight",
+                "title": "Test Book",
+                "author": "Test Author",
+                "url": None,
+                "source_url": "https://example.com/source",
+                "source_type": "article",
+                "category": "article",
+                "location_type": "page",
+                "location": 1,
+                "note": "Test Note",
+                "highlighted_at": "2020-01-01T00:00:00Z",
+                "highlight_url": "https://example.com/highlight",
+                "image_url": "https://example.com/image.jpg",
+                "id": 1,
+                "api_source": None,
+            }
+        ],
+    }
+
+    daily_review = readwise_client.get_daily_review()
+    assert daily_review.review_id == 1
+    assert daily_review.review_url == "https://example.com/review/1"
+    assert daily_review.review_completed is True
+    assert len(daily_review.highlights) == 1
+    assert daily_review.highlights[0]["text"] == "Test Highlight"
+    assert daily_review.highlights[0]["title"] == "Test Book"
+    assert daily_review.highlights[0]["author"] == "Test Author"
+    assert daily_review.highlights[0]["url"] is None
+    assert daily_review.highlights[0]["source_url"] == "https://example.com/source"
+    assert daily_review.highlights[0]["source_type"] == "article"
+    assert daily_review.highlights[0]["category"] == "article"
+    assert daily_review.highlights[0]["location_type"] == "page"
+    assert daily_review.highlights[0]["location"] == 1
+    assert daily_review.highlights[0]["note"] == "Test Note"
+    assert daily_review.highlights[0]["highlighted_at"] == "2020-01-01T00:00:00Z"
+    assert (
+        daily_review.highlights[0]["highlight_url"] == "https://example.com/highlight"
+    )
+    assert daily_review.highlights[0]["image_url"] == "https://example.com/image.jpg"
+    assert daily_review.highlights[0]["id"] == 1
+    assert daily_review.highlights[0]["api_source"] is None
+
+
+@patch.object(Session, "request")
+def test_get_highlights(mock_get):
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "id": 1,
+                "text": "Test Highlight",
+                "note": "Test Note",
+                "location": 1,
+                "location_type": "page",
+                "highlighted_at": "2020-01-01T00:00:00Z",
+                "url": "https://example.com/highlight",
+                "color": "yellow",
+                "updated": "2020-01-01T00:00:00Z",
+                "book_id": 1,
+                "tags": [
+                    {"id": 1, "name": "test_tag"},
+                    {"id": 2, "name": "test_tag_2"},
+                ],
+            }
+        ],
+    }
+
+    highlights = list(readwise_client.get_highlights())
+    assert len(highlights) == 1
+    assert highlights[0].id == 1
+    assert highlights[0].text == "Test Highlight"
+    assert highlights[0].note == "Test Note"
+    assert highlights[0].location == 1
+    assert highlights[0].location_type == "page"
+    assert highlights[0].highlighted_at == "2020-01-01T00:00:00Z"
+    assert highlights[0].url == "https://example.com/highlight"
+    assert highlights[0].color == "yellow"
+    assert highlights[0].updated == "2020-01-01T00:00:00Z"
+    assert highlights[0].book_id == 1
+    assert len(highlights[0].tags) == 2
+    assert highlights[0].tags[0].id == 1
+    assert highlights[0].tags[0].name == "test_tag"
+    assert highlights[0].tags[1].id == 2
+    assert highlights[0].tags[1].name == "test_tag_2"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -5,20 +5,20 @@ from requests import Session
 
 from readwise.api import Readwise, ReadwiseReader
 
-readwise_client = Readwise('test_token')
-readwise_reader = ReadwiseReader('test_token')
+readwise_client = Readwise("test_token")
+readwise_reader = ReadwiseReader("test_token")
 
 
-@patch.object(Session, 'request')
+@patch.object(Session, "request")
 def test_paging(mock_get):
     page1 = Mock()
     page1.status_code = 200
     page1.json.return_value = {
-        'next': 'https://example.com/api/v2/books/?page=2',
-        'results': [
+        "next": "https://example.com/api/v2/books/?page=2",
+        "results": [
             {
-                'id': 1,
-                'title': 'Test Book',
+                "id": 1,
+                "title": "Test Book",
             }
         ],
     }
@@ -26,11 +26,11 @@ def test_paging(mock_get):
     page2 = Mock()
     page2.status_code = 200
     page2.json.return_value = {
-        'next': None,
-        'results': [
+        "next": None,
+        "results": [
             {
-                'id': 2,
-                'title': 'Test Book 2',
+                "id": 2,
+                "title": "Test Book 2",
             }
         ],
     }
@@ -40,115 +40,217 @@ def test_paging(mock_get):
         page2,
     ]
 
-    generator = readwise_client.get_pagination('test/')
+    generator = readwise_client.get_pagination("test/")
     assert next(generator) == page1.json.return_value
     assert next(generator) == page2.json.return_value
 
 
-@patch.object(Session, 'request')
+@patch.object(Session, "request")
 def test_get_books_empty(mock_get):
     mock_get.return_value.status_code = 200
-    mock_get.return_value.json.return_value = {'results': [], 'next': None}
-    highlights = list(readwise_client.get_books('articles'))
+    mock_get.return_value.json.return_value = {"results": [], "next": None}
+    highlights = list(readwise_client.get_books("articles"))
     assert len(highlights) == 0
 
 
-@patch.object(Session, 'request')
+@patch.object(Session, "request")
 def test_get_books(mock_get):
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {
-        'next': None,
-        'results': [
+        "next": None,
+        "results": [
             {
-                'id': 1,
-                'title': 'Test Book',
-                'author': 'Test Author',
-                'category': 'article',
-                'source': 'Test Source',
-                'num_highlights': 1,
-                'last_highlight_at': '2022-12-27T11:33:09Z',
-                'updated': '2020-01-01T00:00:00Z',
-                'cover_image_url': 'https://example.com/image.jpg',
-                'highlights_url': 'https://example.com/highlights',
-                'source_url': 'https://example.com/source',
-                'asin': 'test_asin',
-                'tags': [
-                    {'id': 1, 'name': 'test_tag'},
-                    {'id': 2, 'name': 'test_tag_2'},
+                "id": 1,
+                "title": "Test Book",
+                "author": "Test Author",
+                "category": "article",
+                "source": "Test Source",
+                "num_highlights": 1,
+                "last_highlight_at": "2022-12-27T11:33:09Z",
+                "updated": "2020-01-01T00:00:00Z",
+                "cover_image_url": "https://example.com/image.jpg",
+                "highlights_url": "https://example.com/highlights",
+                "source_url": "https://example.com/source",
+                "asin": "test_asin",
+                "tags": [
+                    {"id": 1, "name": "test_tag"},
+                    {"id": 2, "name": "test_tag_2"},
                 ],
-                'document_note': 'test_note',
+                "document_note": "test_note",
             }
         ],
     }
-    books = list(readwise_client.get_books('articles'))
+    books = list(readwise_client.get_books("articles"))
     assert len(books) == 1
     assert books[0].id == 1
-    assert books[0].title == 'Test Book'
-    assert books[0].author == 'Test Author'
-    assert books[0].category == 'article'
-    assert books[0].source == 'Test Source'
+    assert books[0].title == "Test Book"
+    assert books[0].author == "Test Author"
+    assert books[0].category == "article"
+    assert books[0].source == "Test Source"
     assert books[0].num_highlights == 1
-    assert books[0].last_highlight_at == datetime.fromisoformat('2022-12-27T11:33:09Z')
-    assert books[0].updated == datetime.fromisoformat('2020-01-01T00:00:00Z')
-    assert books[0].cover_image_url == 'https://example.com/image.jpg'
-    assert books[0].highlights_url == 'https://example.com/highlights'
-    assert books[0].source_url == 'https://example.com/source'
-    assert books[0].asin == 'test_asin'
+    assert books[0].last_highlight_at == datetime.fromisoformat("2022-12-27T11:33:09Z")
+    assert books[0].updated == datetime.fromisoformat("2020-01-01T00:00:00Z")
+    assert books[0].cover_image_url == "https://example.com/image.jpg"
+    assert books[0].highlights_url == "https://example.com/highlights"
+    assert books[0].source_url == "https://example.com/source"
+    assert books[0].asin == "test_asin"
     assert len(books[0].tags) == 2
     assert books[0].tags[0].id == 1
-    assert books[0].tags[0].name == 'test_tag'
+    assert books[0].tags[0].name == "test_tag"
     assert books[0].tags[1].id == 2
-    assert books[0].tags[1].name == 'test_tag_2'
-    assert books[0].document_note == 'test_note'
+    assert books[0].tags[1].name == "test_tag_2"
+    assert books[0].document_note == "test_note"
 
 
-@patch.object(Session, 'request')
+@patch.object(Session, "request")
 def test_get_book_highlights_empty(mock_get):
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {
-        'next': None,
-        'results': [],
+        "next": None,
+        "results": [],
     }
-    highlights = list(readwise_client.get_book_highlights('1'))
+    highlights = list(readwise_client.get_book_highlights("1"))
     assert len(highlights) == 0
 
 
-@patch.object(Session, 'request')
+@patch.object(Session, "request")
 def test_get_book_highlights(mock_get):
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {
-        'next': None,
-        'results': [
+        "next": None,
+        "results": [
             {
-                'id': 1,
-                'text': 'Test Highlight',
-                'note': 'Test Note',
-                'location': 1,
-                'location_type': 'page',
-                'url': 'https://example.com/highlight',
-                'color': 'yellow',
-                'updated': '2020-01-01T00:00:00Z',
-                'book_id': 1,
-                'tags': [
-                    {'id': 1, 'name': 'test_tag'},
-                    {'id': 2, 'name': 'test_tag_2'},
+                "id": 1,
+                "text": "Test Highlight",
+                "note": "Test Note",
+                "location": 1,
+                "location_type": "page",
+                "url": "https://example.com/highlight",
+                "color": "yellow",
+                "updated": "2020-01-01T00:00:00Z",
+                "book_id": 1,
+                "tags": [
+                    {"id": 1, "name": "test_tag"},
+                    {"id": 2, "name": "test_tag_2"},
                 ],
             }
         ],
     }
-    highlights = list(readwise_client.get_book_highlights('1'))
+    highlights = list(readwise_client.get_book_highlights("1"))
     assert len(highlights) == 1
     assert highlights[0].id == 1
-    assert highlights[0].text == 'Test Highlight'
-    assert highlights[0].note == 'Test Note'
+    assert highlights[0].text == "Test Highlight"
+    assert highlights[0].note == "Test Note"
     assert highlights[0].location == 1
-    assert highlights[0].location_type == 'page'
-    assert highlights[0].url == 'https://example.com/highlight'
-    assert highlights[0].color == 'yellow'
-    assert highlights[0].updated == datetime.fromisoformat('2020-01-01T00:00:00Z')
+    assert highlights[0].location_type == "page"
+    assert highlights[0].url == "https://example.com/highlight"
+    assert highlights[0].color == "yellow"
+    assert highlights[0].updated == datetime.fromisoformat("2020-01-01T00:00:00Z")
     assert highlights[0].book_id == 1
     assert len(highlights[0].tags) == 2
     assert highlights[0].tags[0].id == 1
-    assert highlights[0].tags[0].name == 'test_tag'
+    assert highlights[0].tags[0].name == "test_tag"
     assert highlights[0].tags[1].id == 2
-    assert highlights[0].tags[1].name == 'test_tag_2'
+    assert highlights[0].tags[1].name == "test_tag_2"
+
+
+@patch.object(Session, "request")
+def test_get_export_highlights(mock_get):
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "count": 1,
+        "nextPageCursor": None,
+        "results": [
+            {
+                "user_book_id": 1,
+                "title": "Test Book",
+                "author": "Test Author",
+                "readable_title": "Test Book",
+                "source": "Test Source",
+                "cover_image_url": "https://example.com/image.jpg",
+                "unique_url": "https://example.com/highlights",
+                "book_tags": [
+                    {"id": 1, "name": "test_tag"},
+                    {"id": 2, "name": "test_tag_2"},
+                ],
+                "category": "article",
+                "document_note": "test_note",
+                "summary": "",
+                "readwise_url": "https://example.com/readwise",
+                "source_url": "https://example.com/source",
+                "asin": None,
+                "highlights": [
+                    {
+                        "id": 1,
+                        "text": "Test Highlight",
+                        "location": 1,
+                        "location_type": "page",
+                        "note": "Test Note",
+                        "color": "yellow",
+                        "highlighted_at": "2020-01-01T00:00:00Z",
+                        "created_at": "2020-01-01T00:00:00Z",
+                        "updated_at": "2020-01-01T00:00:00Z",
+                        "external_id": "test_id",
+                        "end_location": None,
+                        "url": None,
+                        "book_id": 1,
+                        "tags": [
+                            {"id": 1, "name": "test_tag"},
+                            {"id": 2, "name": "test_tag_2"},
+                        ],
+                        "is_favorite": False,
+                        "is_discard": False,
+                        "readwise_url": "https://example.com/readwise",
+                    }
+                ],
+            }
+        ],
+    }
+    export = list(readwise_client.get_export_highlights())
+    assert len(export) == 1
+    assert export[0].user_book_id == 1
+    assert export[0].title == "Test Book"
+    assert export[0].author == "Test Author"
+    assert export[0].readable_title == "Test Book"
+    assert export[0].source == "Test Source"
+    assert export[0].cover_image_url == "https://example.com/image.jpg"
+    assert export[0].unique_url == "https://example.com/highlights"
+    assert len(export[0].book_tags) == 2
+    assert export[0].book_tags[0].id == 1
+    assert export[0].book_tags[0].name == "test_tag"
+    assert export[0].book_tags[1].id == 2
+    assert export[0].book_tags[1].name == "test_tag_2"
+    assert export[0].category == "article"
+    assert export[0].document_note == "test_note"
+    assert export[0].summary == ""
+    assert export[0].readwise_url == "https://example.com/readwise"
+    assert export[0].source_url == "https://example.com/source"
+    assert export[0].asin is None
+    assert len(export[0].highlights) == 1
+    assert export[0].highlights[0].id == 1
+    assert export[0].highlights[0].text == "Test Highlight"
+    assert export[0].highlights[0].location == 1
+    assert export[0].highlights[0].location_type == "page"
+    assert export[0].highlights[0].note == "Test Note"
+    assert export[0].highlights[0].color == "yellow"
+    assert export[0].highlights[0].highlighted_at == datetime.fromisoformat(
+        "2020-01-01T00:00:00Z"
+    )
+    assert export[0].highlights[0].created_at == datetime.fromisoformat(
+        "2020-01-01T00:00:00Z"
+    )
+    assert export[0].highlights[0].updated_at == datetime.fromisoformat(
+        "2020-01-01T00:00:00Z"
+    )
+    assert export[0].highlights[0].external_id == "test_id"
+    assert export[0].highlights[0].end_location is None
+    assert export[0].highlights[0].url is None
+    assert export[0].highlights[0].book_id == 1
+    assert len(export[0].highlights[0].tags) == 2
+    assert export[0].highlights[0].tags[0].id == 1
+    assert export[0].highlights[0].tags[0].name == "test_tag"
+    assert export[0].highlights[0].tags[1].id == 2
+    assert export[0].highlights[0].tags[1].name == "test_tag_2"
+    assert export[0].highlights[0].is_favorite is False
+    assert export[0].highlights[0].is_discard is False
+    assert export[0].highlights[0].readwise_url == "https://example.com/readwise"


### PR DESCRIPTION
This PR addresses Issue #78 with pagination of the `/export/` endpoint and adds new methods 

### Added
- New methods `export_highlights`, `get_daily_review`, `get_daily_review_highlights`, and `get_highlights` to `Readwise` class
- Add `ReadwiseExportHighlight`, `ReadwiseExportResults`, `ReadwiseDailyReview`, and `DailyReviewHighlight` dataclasses
- Add unit tests for new methods



